### PR TITLE
fix error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6284,9 +6284,9 @@
       }
     },
     "protocol-common": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/protocol-common/-/protocol-common-0.1.27.tgz",
-      "integrity": "sha512-HkY+fOBeOqMklydz7Lk25wyTnBzHVZqwBjq67wand6pp0xtoRW+PKG5pvWcKZOQ+KJYjbLb3lAUHqhqziw895w==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/protocol-common/-/protocol-common-0.1.28.tgz",
+      "integrity": "sha512-fYd6WhVcsKEDjiWF+qWEckAI+mjQ/agX9xdy3IEy0G2kM/2orFc+FvIq8PuhXqkbYw54Nne1UDa4Vfgt4UoykA==",
       "requires": {
         "@nestjs/common": "^7.6.5",
         "@nestjs/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Generic controller for aries agents",
   "license": "Apache-2.0",
   "type": "commonjs",
@@ -48,7 +48,7 @@
     "express-rate-limit": "^5.2.3",
     "express-request-id": "^1.4.1",
     "helmet": "^4.2.0",
-    "protocol-common": "^0.1.27",
+    "protocol-common": "^0.1.28",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.6.3",
     "swagger-ui-express": "^4.1.5",


### PR DESCRIPTION
I've noticed this kind of error a few times:
(node:44079) UnhandledPromiseRejectionWarning: TypeError: instance.getTimestamp is not a function
    at Function.printMessage (/Users/jsaur/projects/protocol-all/aries-controller/node_modules/@nestjs/common/services/logger.service.js:100:58)
    at Function.warn (/Users/jsaur/projects/protocol-all/aries-controller/node_modules/@nestjs/common/services/logger.service.js:56:14)
    at /Users/jsaur/projects/protocol-all/aries-controller/node_modules/src/protocol.http.service.ts:57:36
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
(Use `node --trace-warnings ...` to show where the warning was created)

The trick is that often the nestjs common version between protocol-common, aries-controller and whichever service is using those 2 have some kind of mismatch. Updating to the lastest protocol-common here fixes it

Signed-off-by: Jacob Saur <jsaur@kiva.org>