### PR TITLE
make fetching cred def it dynamic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Generic controller for aries agents",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
Instead of hard coding cred_def_id, this fetches the stored value from aca-py /credential-definitions/created (it should always be the case that the agent that created the cred def is the one issuing the credential)
Signed-off-by: Jacob Saur <jsaur@kiva.org>