### PR TITLE
PRO-2742: datadog tags shouldn't just use "controllers"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Generic controller for aries agents",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -46,7 +46,7 @@ export class AppService {
         app.useGlobalFilters(new ProtocolExceptionFilter());
         app.useGlobalInterceptors(new LoggingInterceptor());
 
-        app.use(traceware('controllers'));
+        app.use(traceware(process.env.SERVICE_NAME));
 
         // Default is 100 requests per minute
         app.use(rateLimit({


### PR DESCRIPTION
Blocks this PR in protocol-aries: [#112](https://github.com/kiva/protocol-aries/pull/112)

Original ticket: [PRO-2742](https://kiva.atlassian.net/browse/PRO-2742)

Summary of changes:
* Use SERVICE_NAME environment variable for traceware in order to differentiate between different controllers, instead of just calling everything "controllers".
* Update version to 1.0.22 so controller implementations can take advantage of this update immediately

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>