### PR TITLE
PRO-2868: Update the version to 1.0.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Generic controller for aries agents",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
After merging with master, the version update got lost in the merge. It needs another update to get the latest changes out.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>