### PR TITLE
Creating DTOs that define the basic message body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "Generic controller for aries agents",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/agent/messaging/README.md
+++ b/src/agent/messaging/README.md
@@ -1,0 +1,10 @@
+## Messages
+
+Messages are structures sent in the "content" part of a basic message.  
+
+BasicMessage is like an envelope and the content is only known between sender and receiver.
+The Messages defined the content.
+
+See [RFC](https://github.com/hyperledger/aries-rfcs/tree/master/features/0095-basic-message)
+for details on the basic message structure.
+

--- a/src/agent/messaging/README.md
+++ b/src/agent/messaging/README.md
@@ -2,8 +2,8 @@
 
 Messages are structures sent in the "content" part of a basic message.  
 
-BasicMessage is like an envelope and the content is only known between sender and receiver.
-The Messages defined the content.
+Basic message is like an envelope with the content known between sender and receiver.
+The messages defined here become the content of a basic message.
 
 See [RFC](https://github.com/hyperledger/aries-rfcs/tree/master/features/0095-basic-message)
 for details on the basic message structure.

--- a/src/agent/messaging/credit.report.ts
+++ b/src/agent/messaging/credit.report.ts
@@ -1,0 +1,30 @@
+/**
+ *
+ */
+export class CreditReport {
+    /**
+     * always "credit_report", used by basicmessage handlers to identity the message type
+     */
+    public readonly messageTypeId: string = 'credit_report';
+    /**
+     * started, completed, rejected
+     */
+    public readonly state: string;
+    /**
+     * unique Id for the message, assigned by FSP
+     */
+    public readonly id: string;
+    /**
+     * TDC assigned Id for the TRO, public to the FSP
+     */
+    public readonly tdcTroId: string;
+    /**
+     * TDC assigned Id for the Fsp, public to the TRO
+     */
+    public readonly tdcFspId: string;
+    /**
+     * When state is completed, contains the credit report
+     * todo: replace any with type, may need generic as report format could be different per use case
+     */
+    public readonly report: Array<any>;
+}

--- a/src/agent/messaging/credit.report.ts
+++ b/src/agent/messaging/credit.report.ts
@@ -26,5 +26,5 @@ export class CreditReport<T> {
      * When state is completed, contains the credit report
      * report data is unique to use case
      */
-    public readonly report: Array<T>;
+    public readonly report: T[];
 }

--- a/src/agent/messaging/credit.report.ts
+++ b/src/agent/messaging/credit.report.ts
@@ -1,7 +1,7 @@
 /**
  *
  */
-export class CreditReport {
+export class CreditReport<T> {
     /**
      * always "credit_report", used by basicmessage handlers to identity the message type
      */
@@ -24,7 +24,7 @@ export class CreditReport {
     public readonly tdcFspId: string;
     /**
      * When state is completed, contains the credit report
-     * todo: replace any with type, may need generic as report format could be different per use case
+     * report data is unique to use case
      */
-    public readonly report: Array<any>;
+    public readonly report: Array<T>;
 }

--- a/src/agent/messaging/credit.transaction.ts
+++ b/src/agent/messaging/credit.transaction.ts
@@ -1,0 +1,26 @@
+/**
+ * Sent by TDC to the TRO for the TRO record verification handlers.  The TRO should already
+ * have this data in the form of a credential.
+ */
+export class CreditTransaction<T> {
+    /**
+     * always "credit_transaction", used by basicmessage handlers to identity the message type
+     */
+    public readonly messageTypeId: string = 'credit_transaction';
+    /**
+     * started, completed, accepted, rejected
+     */
+    public readonly state: string;
+    /**
+     * unique Id for the message, assigned by TDC
+     */
+    public readonly id: string;
+    /**
+     * id of the credential used to put the transaction on the ledger
+     */
+    public readonly credentialId: string;
+    /**
+     * transaction data, specific to use case
+     */
+    public readonly transaction: T;
+}

--- a/src/agent/messaging/tdc.grant.ts
+++ b/src/agent/messaging/tdc.grant.ts
@@ -1,0 +1,26 @@
+
+/**
+ * For TDC Grant basic messaging between TRO and FSP
+ */
+export class TdcGrant {
+    /**
+     * always "grant", used by basicmessage handlers to identity the message type
+     */
+    public readonly messageTypeId: string = 'grant';
+    /**
+     * started, completed, accepted, rejected
+     */
+    public readonly state: string;
+    /**
+     * unique Id for the message, assigned by TDC
+     */
+    public readonly id: string;
+    /**
+     * TDC assigned Id for the TRO, public to the FSP
+     */
+    public readonly tdcTroId: string;
+    /**
+     * TDC assigned Id for the Fsp, public to the TRO
+     */
+    public readonly tdcFspId: string;
+}

--- a/src/agent/messaging/transaction.request.ts
+++ b/src/agent/messaging/transaction.request.ts
@@ -1,0 +1,30 @@
+/**
+ *
+ */
+export class TransactionRequest {
+    /**
+     * always "transaction_request", used by basicmessage handlers to identity the message type
+     */
+    public readonly messageTypeId: string = 'transaction_request';
+    /**
+     * started, completed
+     */
+    public readonly state: string;
+    /**
+     * unique Id for the message, assigned by FSP
+     */
+    public readonly id: string;
+    /**
+     * TDC assigned Id for the TRO, public to the FSP
+     */
+    public readonly tdcTroId: string;
+    /**
+     * TDC assigned Id for the Fsp, public to the TRO
+     */
+    public readonly tdcFspId: string;
+    /**
+     * When state is completed, will contain array of transactions
+     * todo: replace any with type, may need generic as transactions could be different per use case
+     */
+    public readonly transactions: Array<any>;
+}

--- a/src/agent/messaging/transaction.request.ts
+++ b/src/agent/messaging/transaction.request.ts
@@ -27,5 +27,5 @@ export class TransactionRequest<T> {
      * When state is completed, will contain array of transactions
      * transaction format is unique to use case
      */
-    public readonly transactions: Array<T>;
+    public readonly transactions: T[];
 }

--- a/src/agent/messaging/transaction.request.ts
+++ b/src/agent/messaging/transaction.request.ts
@@ -1,7 +1,8 @@
 /**
- *
+ *  Used between TDC and TRO to build a credit report when requested from FSP (FSP
+ *  sends a different message).
  */
-export class TransactionRequest {
+export class TransactionRequest<T> {
     /**
      * always "transaction_request", used by basicmessage handlers to identity the message type
      */
@@ -24,7 +25,7 @@ export class TransactionRequest {
     public readonly tdcFspId: string;
     /**
      * When state is completed, will contain array of transactions
-     * todo: replace any with type, may need generic as transactions could be different per use case
+     * transaction format is unique to use case
      */
-    public readonly transactions: Array<any>;
+    public readonly transactions: Array<T>;
 }


### PR DESCRIPTION
Basic Message is an [aries defined protocol](https://github.com/hyperledger/aries-rfcs/tree/master/features/0095-basic-message).  The basic message serves as an envelope.  The body (aka the `content` field of basic message) of the message is known between sender and receiver and not defined by the RFC.  

These DTOs define the body.  Some additional structure will be applied once we have more details from HRC or other client.