### PR TITLE
update metadata field to reflect what we do in Auth0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "aries-controller",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.60",
+      "version": "1.0.61",
       "license": "Apache-2.0",
       "dependencies": {
         "@nestjs/common": "^7.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Generic controller for aries agents",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/utility/agent.context.ts
+++ b/src/utility/agent.context.ts
@@ -52,7 +52,8 @@ export class AgentContext {
             throw new ProtocolException(ProtocolErrorCode.FORBIDDEN_EXCEPTION, 'AgentContext: Failed to decode JWT', null, 403);
         }
 
-        const agentId: string = metaData.agent;
+        // Custom claims on a OIDC-compliant requires a URI namespace, for generic protocol metadata in Auth0 we use https://protocol.kiva.org/
+        const agentId: string = metaData['https://protocol.kiva.org/agent'];
         if (!agentId) {
             throw new ProtocolException(ProtocolErrorCode.FORBIDDEN_EXCEPTION, 'AgentContext: No agent attribute in token metadata', null, 403);
         }


### PR DESCRIPTION
This updates the Auth0 token metadata field name for agent - it needs to include the namespace URI to to OpenID Connect compliant (Auth0 doesn't allow anything else)
Signed-off-by: Jacob Saur <jsaur@kiva.org>