### PR TITLE
fix change from problem report to error_msg in presentation exchange

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ jobs:
       - run:
           name: setup docker environments
           command: |
-            docker pull bcgovimages/aries-cloudagent:py36-1.16-1_0.7.0
             docker pull bcgovimages/aries-cloudagent:py36-1.16-1_0.7.1
       - run:
           name: Start docker compose and wait for readiness

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
           name: setup docker environments
           command: |
             docker pull bcgovimages/aries-cloudagent:py36-1.16-1_0.7.0
+            docker pull bcgovimages/aries-cloudagent:py36-1.16-1_0.7.1
       - run:
           name: Start docker compose and wait for readiness
           command: |

--- a/docker-compose.dep.yml
+++ b/docker-compose.dep.yml
@@ -83,7 +83,7 @@ services:
             - POSTGRES_PASSWORD=dbpass
 
     multitenant:
-        image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.0
+        image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.1
         container_name: ac-multitenant
         networks:
           - agency-network

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "Generic controller for aries agents",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/controller/handler/problem.report.ts
+++ b/src/controller/handler/problem.report.ts
@@ -24,9 +24,9 @@ export class ProblemReport extends BaseAgentResponseHandler {
             return;
 
         // Cache problem message by thread id
-        if (body && body['~thread'] && body['explain-ltxt']) {
+        if (body && body['~thread'] && body.description) {
             const threadId = body['~thread'].thid;
-            await this.cache.set(threadId, body['explain-ltxt']);
+            await this.cache.set(threadId, body.description);
         }
         return 'ok';
     }

--- a/src/controller/handler/proof.ts
+++ b/src/controller/handler/proof.ts
@@ -173,7 +173,7 @@ export class Proofs extends BaseAgentResponseHandler {
                 const problemReportReq: AxiosRequestConfig = super.createHttpRequest(url, adminApiKey, token);
                 // We send JSON encoded code & message to allow easily throwing a protocol exception
                 problemReportReq.data = {
-                    explain_ltxt: JSON.stringify({
+                    description: JSON.stringify({
                         code: ProtocolErrorCode.PROOF_FAILED_UNFULFILLED,
                         message: 'No credentials found to match proof request'
                     })
@@ -201,7 +201,7 @@ export class Proofs extends BaseAgentResponseHandler {
             for (const predicateKey in presentationRequest.requested_predicates) {
                 if (credentials[predicateKey]) {
                     requested_predicates[predicateKey] = {
-                        cred_id: credentials[predicateKey].cred_info.referent
+                        cred_id: credentials[predicateKey].cred_info.referent,
                     };
                 }
             }


### PR DESCRIPTION
It looks like problem reports have changed in aca-py 0.7. specifically instead of an ‘explain_ltxt’ field in the body, they now call it ‘description’. I discovered this through the aca-py swagger docs and confirmed by changing to ‘description’ and sure enough stopped seeing input errors. However there was still a problem with our verify flow. One other thing they changed is that when you send a problem_report it doesn’t trigger the problem-report webhook (at least for verifications). Instead they’ve added an error_msg attribute onto the proof response which contains anything send in the problem report. So I had to change our verify code to instead of waiting for a problem-report webhook, just check the proof response for the error_msg field and handle the errors as we did before.

Note there is still a problem with 0.7 that needs an update before we can push it, so will wait to merge this until 0.7.1 is out

Signed-off-by: Jacob Saur <jsaur@kiva.org>