### PR TITLE
Add special handling for prod on all agent calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.81",
+  "version": "1.0.83",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.82",
+  "version": "1.0.83",
   "description": "Generic controller for aries agents",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/caller/multi.agent.caller.ts
+++ b/src/caller/multi.agent.caller.ts
@@ -7,6 +7,7 @@ import { ProtocolErrorCode } from 'protocol-common/protocol.errorcode';
 import { ICaller } from './caller.interface';
 import { IControllerHandler, CONTROLLER_HANDLER } from '../controller.handler/controller.handler.interface';
 import { SecretsManager } from '../profile/secrets.manager';
+import { Constants } from 'protocol-common/constants';
 
 /**
  * Handles all calls to the multitenant aca-py agent
@@ -92,6 +93,9 @@ export class MultiAgentCaller implements ICaller {
                 return await this.callAgent(method, route, params, data, false);
             }
             Logger.warn(`Agent call failed to ${url} with ${JSON.stringify(data)}`, e);
+            if (process.env.NODE_ENV === Constants.PROD) {
+                throw new ProtocolException(ProtocolErrorCode.AGENT_CALL_FAILED, `Agent call failed`);
+            }
             throw new ProtocolException(ProtocolErrorCode.AGENT_CALL_FAILED, `Agent: ${e.message}`, { agentRoute: route, ex: e.details });
         }
     }

--- a/src/caller/single.agent.caller.ts
+++ b/src/caller/single.agent.caller.ts
@@ -7,6 +7,7 @@ import { ProtocolErrorCode } from 'protocol-common/protocol.errorcode';
 import { ICaller } from './caller.interface';
 import { IControllerHandler, CONTROLLER_HANDLER } from '../controller.handler/controller.handler.interface';
 import { ProtocolUtility } from 'protocol-common/protocol.utility';
+import { Constants } from 'protocol-common/constants';
 
 /**
  * Caller for a single agent
@@ -86,6 +87,9 @@ export class SingleAgentCaller implements ICaller {
                 return await this.callAgent(method, route, params, data, false);
             }
             Logger.warn(`Agent call failed to ${url} with ${JSON.stringify(data)}`, e);
+            if (process.env.NODE_ENV === Constants.PROD) {
+                throw new ProtocolException(ProtocolErrorCode.AGENT_CALL_FAILED, `Agent call failed`);
+            }
             throw new ProtocolException(ProtocolErrorCode.AGENT_CALL_FAILED, `Agent: ${e.message}`, { agentRoute: route, ex: e.details });
         }
     }


### PR DESCRIPTION
There are 2 places where we call the underlying aries agent and return it's response. Since aca-py often reveals too much info as part of both it's message and it's details we need to hide these from potential hackers in prod. In non-prod environments return the underlying agent message and details is very useful for debugging. In either case we log a detailed message.

Signed-off-by: Jacob Saur <jsaur@kiva.org>