### PR TITLE
Add env flag to not spin up agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.83",
+  "version": "1.0.84",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.83",
+  "version": "1.0.84",
   "description": "Generic controller for aries agents",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/agent/agent.service.ts
+++ b/src/agent/agent.service.ts
@@ -1,4 +1,4 @@
-import { CacheStore, CACHE_MANAGER, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Logger } from 'protocol-common/logger';
 import { ProtocolException } from 'protocol-common/protocol.exception';
 import { ProtocolErrorCode } from 'protocol-common/protocol.errorcode';
@@ -23,8 +23,13 @@ export class AgentService {
 
     /**
      * Spin up agent
+     * If AGENCY_DEPLOY is unset then we still deploy, only if explicitly set to false do we not deploy
+     * This maintains the status quo by default, and we can set each controller to false as we update each agent deployment
      */
     public async init(): Promise<any> {
+        if (process.env.AGENCY_DEPLOY === 'false') {
+            return null;
+        }
         return await this.agentCaller.spinUpAgent();
     }
 


### PR DESCRIPTION
This piece is need as we move towards each config deploying their own agent and not relying on the agency to do it
Signed-off-by: Jacob Saur <jsaur@kiva.org>