### PR TITLE
Upgrade deployed aries-controller version to 1.0.85

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,11 +164,6 @@ jobs:
 workflows:
   build-test-publish:
     jobs:
-      - npm-publish:
-          name: test-npm-publish
-          filters: # run for all branches AND tags
-            tags:
-              only: /.*/
       - build-and-test:
           filters: # run for all branches AND tags
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,11 @@ jobs:
 workflows:
   build-test-publish:
     jobs:
+      - npm-publish:
+          name: test-npm-publish
+          filters: # run for all branches AND tags
+            tags:
+              only: /.*/
       - build-and-test:
           filters: # run for all branches AND tags
             tags:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-controller",
-  "version": "1.0.84",
+  "version": "1.0.85",
   "description": "Generic controller for aries agents",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -19,6 +19,6 @@ else
   # The .npmrc file is only needed for publish and can cause issues when left around, so manually adding here
   echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > dist/.npmrc
   cd dist
-#  npm publish --verbose
+  npm publish --verbose
   cd ..
 fi

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,11 +2,9 @@
 set -ex
 
 # Allow providing a version manually instead of inferring it from package.json
-((localVersion))
+localVersion=$(jq -r '.version' package.json)
 if [ $# -gt 0 ]; then
   localVersion=$1
-else
-  localVersion=$(jq -r '.version' package.json)
 fi
 remoteVersion=$(npm show aries-controller version)
 
@@ -21,6 +19,6 @@ else
   # The .npmrc file is only needed for publish and can cause issues when left around, so manually adding here
   echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > dist/.npmrc
   cd dist
-  npm publish --verbose
+#  npm publish --verbose
   cd ..
 fi


### PR DESCRIPTION
* Upgrade version as a test that the CI/CD updates from the previous PR (https://github.com/kiva/aries-controller/pull/131) work properly.
* Fix an issue with the publish.sh script (used some non-POSIX-compliant sh commands)

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>