### PR TITLE
Hack around CI error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,8 +91,29 @@ jobs:
           name: Get ACAPy
           command: docker pull bcgovimages/aries-cloudagent:py36-1.16-1_0.7.1
       - run:
-          name: Override for gateway image
-          command: ./scripts/setup_override.sh -r aries-controller -s demo-controller -f docker-compose.demo.yml
+          name: Override for demo-controller image
+          command: |
+            ./scripts/setup_override.sh -r aries-controller -s demo-controller -f docker-compose.demo.yml
+            rm -rf tmp
+            echo "$services" | awk '{
+              split($0,arr,",");
+              for (i=1; i<=length(arr); i++) {
+                key=toupper(arr[i])
+                gsub("-", "_", key);
+                print key"_IMAGE="arr[i]":latest"
+              }
+            }' > override.env
+            awk '
+              NF && !/^#/ {
+                gsub("="," ",$0);
+                envvar[$1]=$2;
+              } END {
+                for(key in envvar) {
+                  print key"="envvar[key]
+                }
+              }
+            ' dummy.env override.env > .env
+            rm override.env
       - run:
           name: Start docker compose and wait for readiness
           command: |

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -12,8 +12,7 @@ services:
             - .env
         build:
             context: .
-            dockerfile: Dockerfile
-        command: npm run start:debug
+            dockerfile: Dockerfile.production
         image: demo-controller
         container_name: demo-controller
         working_dir: /www


### PR DESCRIPTION
There's an error in the CI process that will be fixed as part of this PR: https://github.com/kiva/protocol-integration-tests/pull/46

But, because there's a circular dependency, this hack is needed for the very short term.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>